### PR TITLE
Display more relevant data

### DIFF
--- a/cmd/ursrv/main.go
+++ b/cmd/ursrv/main.go
@@ -61,7 +61,7 @@ var funcs = map[string]interface{}{
 			parts = append(parts, part)
 		}
 		if len(input) > 0 {
-			parts = append(parts, input[:len(input)])
+			parts = append(parts, input[:])
 		}
 		return parts[whichPart-1]
 	},
@@ -1329,10 +1329,10 @@ func getReport(db *sql.DB) map[string]interface{} {
 	r["nodes"] = nodes
 	r["versionNodes"] = reports
 	r["categories"] = categories
-	r["versions"] = group(byVersion, analyticsFor(versions, 2000), 5)
+	r["versions"] = group(byVersion, analyticsFor(versions, 2000), 10)
 	r["versionPenetrations"] = penetrationLevels(analyticsFor(versions, 2000), []float64{50, 75, 90, 95})
 	r["platforms"] = group(byPlatform, analyticsFor(platforms, 2000), 5)
-	r["compilers"] = group(byCompiler, analyticsFor(compilers, 2000), 3)
+	r["compilers"] = group(byCompiler, analyticsFor(compilers, 2000), 5)
 	r["builders"] = analyticsFor(builders, 12)
 	r["featureOrder"] = featureOrder
 	r["locations"] = locations

--- a/static/index.html
+++ b/static/index.html
@@ -385,18 +385,20 @@ found in the LICENSE file.
           </thead>
           <tbody>
             {{range .versions}}
-              {{if gt .Percentage 0.5}}
+              {{if gt .Percentage 0.1}}
                 <tr class="main">
                   <td>{{.Key}}</td>
                   <td class="text-right">{{.Count}}</td>
                   <td class="text-right">{{.Percentage | printf "%.01f"}}%</td>
                 </tr>
                 {{range .Items}}
-                  <tr class="child">
-                    <td class="first">{{.Key}}</td>
-                    <td class="text-right">{{.Count}}</td>
-                    <td class="text-right">{{.Percentage | printf "%.01f"}}%</td>
-                  </tr>
+                  {{if gt .Percentage 0.1}}
+                    <tr class="child">
+                      <td class="first">{{.Key}}</td>
+                      <td class="text-right">{{.Count}}</td>
+                      <td class="text-right">{{.Percentage | printf "%.01f"}}%</td>
+                    </tr>
+                  {{end}}
                 {{end}}
               {{end}}
             {{end}}
@@ -470,11 +472,13 @@ found in the LICENSE file.
                 <td class="text-right">{{.Percentage | printf "%.01f"}}%</td>
               </tr>
               {{range .Items}}
-                <tr class="child">
-                  <td class="first">{{.Key}}</td>
-                  <td class="text-right">{{.Count}}</td>
-                  <td class="text-right">{{.Percentage | printf "%.01f"}}%</td>
-                </tr>
+                {{if or (gt .Percentage 0.1) (eq .Key "Others")}}
+                  <tr class="child">
+                    <td class="first">{{.Key}}</td>
+                    <td class="text-right">{{.Count}}</td>
+                    <td class="text-right">{{.Percentage | printf "%.01f"}}%</td>
+                  </tr>
+                {{end}}
               {{end}}
             {{end}}
           </tbody>


### PR DESCRIPTION
At the moment there's quite a bit of white space in our 2-column data display. This changes what's displayed and what's filtered out to something subjectively more relevant (i.e. more major version infos, less hardly used minor version infos):

 - major versions: >0.5 -> >0.1
 - minor versions: no limit -> >0.1
 - minor compiler versions: no limit -> >0.1 or part of "Others" group

I only made sure the server starts, I couldn't actually check that it actually works/does what I want to do due to missing data - so needs to be taken for a test spin first.